### PR TITLE
test(inventory): add Redis integration harness for inventory event flow

### DIFF
--- a/services/inventory-service/jest.config.cjs
+++ b/services/inventory-service/jest.config.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  clearMocks: true,
+  collectCoverage: false,
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
+};

--- a/services/inventory-service/src/__mocks__/redis.ts
+++ b/services/inventory-service/src/__mocks__/redis.ts
@@ -1,0 +1,34 @@
+import { EventEmitter } from 'events';
+
+class MockRedisClient extends EventEmitter {
+  private subscriptions: Map<string, (message: string) => void> = new Map();
+
+  async connect() {
+    return;
+  }
+  duplicate() {
+    return this;
+  }
+  on() {
+    return this;
+  }
+  async subscribe(channel: string, cb: (message: string) => void) {
+    this.subscriptions.set(channel, cb);
+  }
+  async publish(channel: string, message: string) {
+    const cb = this.subscriptions.get(channel);
+    if (cb) {
+      // simulate async delivery
+      setImmediate(() => cb(message));
+    }
+  }
+  async disconnect() {
+    this.subscriptions.clear();
+  }
+}
+
+export function createClient() {
+  return new MockRedisClient();
+}
+
+export type RedisClientType = MockRedisClient;

--- a/services/inventory-service/src/modules/inventory/__tests__/redis.integration.spec.ts
+++ b/services/inventory-service/src/modules/inventory/__tests__/redis.integration.spec.ts
@@ -1,0 +1,30 @@
+jest.mock('redis');
+
+import { RedisEventBusService } from '../infrastructure/events/redis-event-bus.service';
+import { InventoryService } from '../application/inventory.service';
+
+describe('RedisEventBusService integration (mocked redis)', () => {
+  it('should handle order.created and publish inventory.locked when stock reserved', async () => {
+    // Create a mock inventory service that always reserves
+    const mockInventoryService: any = {
+      lockStock: jest.fn(async (orderId: string, productId: string, quantity: number) => ({ success: true, lockId: 'lock123', source: 'STORE' })),
+    };
+
+    const bus = new RedisEventBusService(mockInventoryService as InventoryService);
+
+    // Force non-test env so onModuleInit runs logic; but redis is mocked
+    process.env.NODE_ENV = 'development';
+    await bus.onModuleInit();
+
+    // Publish an order.created message using the internal pub client
+    // @ts-ignore access private field for test
+    const pub = (bus as any).pubClient;
+    await pub.publish('order.created', JSON.stringify({ orderId: 'o1', productId: 'p1', quantity: 2 }));
+
+    // wait a tick for async handlers
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Expect inventory service lockStock to have been called
+    expect(mockInventoryService.lockStock).toHaveBeenCalledWith('o1', 'p1', 2);
+  });
+});


### PR DESCRIPTION
### Pull Request Description

- **Summary:** Add a Redis integration test harness for inventory service, including `ts-jest` configuration, a Redis module mock, and an integration spec for the `order.created -> inventory.lockStock` flow.
- **Related Issue:** #83

### Changes

- **Jest Config**: Added `services/inventory-service/jest.config.cjs` for TypeScript test execution via `ts-jest`.
- **Redis Mock**: Added `services/inventory-service/src/__mocks__/redis.ts` to simulate pub/sub behavior locally.
- **Integration Spec**: Added `services/inventory-service/src/modules/inventory/__tests__/redis.integration.spec.ts` covering event handling.

### Validation

- Unit/integration tests were executed successfully in the inventory service workspace.

### Notes

- `tmp/` was intentionally excluded from the commit.
- This branch is isolated from delivery-service changes and is based on the current `main` branch.
