### PR TITLE
feat(clothing-store): add apparel storefront app

### DIFF
--- a/apps/web/clothing-store/jsconfig.json
+++ b/apps/web/clothing-store/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/apps/web/clothing-store/next-env.d.ts
+++ b/apps/web/clothing-store/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/web/clothing-store/next.config.js
+++ b/apps/web/clothing-store/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+  compiler: {
+    removeConsole: process.env.NODE_ENV === 'production',
+  },
+};
+
+module.exports = nextConfig;

--- a/apps/web/clothing-store/package.json
+++ b/apps/web/clothing-store/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "clothing-store-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3021",
+    "build": "next build",
+    "start": "next start -p 3021",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "axios": "^1.6.0",
+    "next": "^14.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "autoprefixer": "^10.4.0",
+    "eslint": "^8.0.0",
+    "eslint-config-next": "^14.0.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/apps/web/clothing-store/postcss.config.js
+++ b/apps/web/clothing-store/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/clothing-store/src/app/cart/page.tsx
+++ b/apps/web/clothing-store/src/app/cart/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link from 'next/link';
+import AppShell from '@/components/AppShell';
+import { useCartStore } from '@/store';
+
+export default function CartPage() {
+  const items = useCartStore((state) => state.items);
+  const removeItem = useCartStore((state) => state.removeItem);
+  const setQuantity = useCartStore((state) => state.setQuantity);
+
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  return (
+    <AppShell>
+      <div className="space-y-6">
+        <h1 className="text-3xl font-heading">Your cart</h1>
+        {items.length === 0 ? (
+          <div className="card p-6">
+            <p className="text-muted">Your cart is empty.</p>
+            <Link className="btn-primary mt-4 inline-flex" href="/products">
+              Browse apparel
+            </Link>
+          </div>
+        ) : (
+          <div className="card p-6">
+            <div className="space-y-4">
+              {items.map((item) => (
+                <div key={item.id} className="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <p className="text-lg font-semibold">{item.name}</p>
+                    <p className="text-sm text-muted">${item.price.toFixed(0)}</p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <input
+                      type="number"
+                      min={1}
+                      value={item.quantity}
+                      onChange={(event) =>
+                        setQuantity(item.id, Number(event.target.value))
+                      }
+                      className="w-16 rounded-full border border-white/70 bg-white/80 px-3 py-1 text-center text-sm"
+                    />
+                    <button
+                      className="btn-secondary"
+                      onClick={() => removeItem(item.id)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="mt-6 flex items-center justify-between border-t border-white/70 pt-4">
+              <span className="text-lg font-semibold">Total</span>
+              <span className="text-2xl font-semibold">${total.toFixed(0)}</span>
+            </div>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/clothing-store/src/app/checkout/page.tsx
+++ b/apps/web/clothing-store/src/app/checkout/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import AppShell from '@/components/AppShell';
+import { useCartStore } from '@/store';
+
+export default function CheckoutPage() {
+  const items = useCartStore((state) => state.items);
+  const clearCart = useCartStore((state) => state.clearCart);
+  const [isPlaced, setIsPlaced] = useState(false);
+
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsPlaced(true);
+    clearCart();
+  };
+
+  return (
+    <AppShell>
+      <div className="space-y-6">
+        <h1 className="text-3xl font-heading">Checkout</h1>
+
+        {items.length === 0 ? (
+          <div className="card p-6">
+            <p className="text-muted">Your cart is empty.</p>
+            <Link className="btn-primary mt-4 inline-flex" href="/products">
+              Browse apparel
+            </Link>
+          </div>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+            <form className="card space-y-4 p-6" onSubmit={handleSubmit}>
+              <div className="grid gap-4 md:grid-cols-2">
+                <input
+                  required
+                  placeholder="Full name"
+                  className="rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+                />
+                <input
+                  required
+                  type="email"
+                  placeholder="Email"
+                  className="rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+                />
+              </div>
+              <input
+                required
+                placeholder="Street address"
+                className="w-full rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+              />
+              <div className="grid gap-4 md:grid-cols-2">
+                <input
+                  required
+                  placeholder="City"
+                  className="rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+                />
+                <input
+                  required
+                  placeholder="Postal code"
+                  className="rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+                />
+              </div>
+              <button className="btn-primary" type="submit">
+                Place order
+              </button>
+              {isPlaced && (
+                <p className="text-sm text-muted">
+                  Order placed. A confirmation email is on the way.
+                </p>
+              )}
+            </form>
+            <div className="card p-6">
+              <h2 className="text-xl font-semibold">Order summary</h2>
+              <div className="mt-4 space-y-2 text-sm text-muted">
+                {items.map((item) => (
+                  <div key={item.id} className="flex justify-between">
+                    <span>
+                      {item.name} x {item.quantity}
+                    </span>
+                    <span>${(item.price * item.quantity).toFixed(0)}</span>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-4 flex justify-between border-t border-white/70 pt-4 text-lg font-semibold">
+                <span>Total</span>
+                <span>${total.toFixed(0)}</span>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/clothing-store/src/app/dashboard/page.tsx
+++ b/apps/web/clothing-store/src/app/dashboard/page.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import AppShell from '@/components/AppShell';
+import ProtectedGate from '@/components/ProtectedGate';
+import { useAuthStore } from '@/store';
+import { brand, dashboardRoles } from '@/lib/brand';
+
+const stats = [
+  { label: 'Orders today', value: '38' },
+  { label: 'Returns', value: '2' },
+  { label: 'Low stock', value: '5' },
+  { label: 'Active promos', value: '4' },
+];
+
+export default function DashboardPage() {
+  const user = useAuthStore((state) => state.user);
+
+  return (
+    <AppShell>
+      <ProtectedGate requiredRoles={dashboardRoles}>
+        <div className="space-y-8">
+          <div className="card p-6">
+            <p className="text-sm uppercase tracking-[0.2em] text-muted">
+              {brand.name} operations
+            </p>
+            <h1 className="text-3xl font-heading">Welcome back, {user?.fullName || 'Team'}</h1>
+            <p className="text-sm text-muted">Role: {user?.roles?.join(', ') || 'ADMIN'}</p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            {stats.map((stat) => (
+              <div key={stat.label} className="card p-5">
+                <p className="text-sm text-muted">{stat.label}</p>
+                <p className="text-2xl font-semibold">{stat.value}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            <div className="card p-6">
+              <h2 className="text-xl font-semibold">Merchandising focus</h2>
+              <p className="mt-2 text-sm text-muted">
+                Essentials are trending up. Schedule reorder for core tees.
+              </p>
+              <button className="btn-secondary mt-4">Open assortment</button>
+            </div>
+            <div className="card p-6">
+              <h2 className="text-xl font-semibold">Clienteling</h2>
+              <p className="mt-2 text-sm text-muted">
+                VIP list needs styling outreach before the weekend launch.
+              </p>
+              <button className="btn-secondary mt-4">View notes</button>
+            </div>
+          </div>
+        </div>
+      </ProtectedGate>
+    </AppShell>
+  );
+}

--- a/apps/web/clothing-store/src/app/globals.css
+++ b/apps/web/clothing-store/src/app/globals.css
@@ -1,0 +1,74 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --brand: #5b7b7a;
+  --accent: #d9a7a7;
+  --surface: #f7f1eb;
+  --surface-2: #efe4da;
+  --ink: #1e1d1b;
+  --muted: #6d645b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  @apply font-body text-ink;
+  background:
+    radial-gradient(900px 500px at 15% -20%, rgba(217, 167, 167, 0.35), transparent 60%),
+    radial-gradient(800px 400px at 85% 10%, rgba(91, 123, 122, 0.22), transparent 55%),
+    linear-gradient(180deg, var(--surface), #f9f4ef 60%, var(--surface-2));
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+.card {
+  @apply rounded-2xl bg-white/80 backdrop-blur border border-white/60 shadow-glow;
+}
+
+.btn-primary {
+  @apply inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold text-white;
+  background: linear-gradient(135deg, var(--brand), #84a6a4);
+}
+
+.btn-secondary {
+  @apply inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold;
+  background: white;
+  border: 1px solid rgba(30, 29, 27, 0.12);
+}
+
+.brand-chip {
+  @apply inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs uppercase tracking-[0.2em];
+  background: rgba(91, 123, 122, 0.12);
+  color: var(--brand);
+}
+
+.section-title {
+  @apply text-3xl md:text-4xl font-heading tracking-wide;
+}
+
+.animate-rise {
+  animation: rise 0.6s ease-out both;
+}
+
+.animate-rise-delayed {
+  animation: rise 0.8s ease-out both;
+  animation-delay: 0.1s;
+}
+
+@keyframes rise {
+  from {
+    transform: translateY(12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}

--- a/apps/web/clothing-store/src/app/layout.tsx
+++ b/apps/web/clothing-store/src/app/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next';
+import { Cormorant_Garamond, Source_Sans_3 } from 'next/font/google';
+import './globals.css';
+
+const bodyFont = Source_Sans_3({
+  weight: '400',
+  subsets: ['latin'],
+  variable: '--font-body',
+});
+
+const headingFont = Cormorant_Garamond({
+  weight: '600',
+  subsets: ['latin'],
+  variable: '--font-heading',
+});
+
+export const metadata: Metadata = {
+  title: 'Clothing Atelier',
+  description: 'Layered essentials and tailored silhouettes.',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" className={`${bodyFont.variable} ${headingFont.variable}`}>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/clothing-store/src/app/login/page.tsx
+++ b/apps/web/clothing-store/src/app/login/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import AppShell from '@/components/AppShell';
+import { authApi } from '@/lib/api';
+import { useAuthStore } from '@/store';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const setAuth = useAuthStore((state) => state.setAuth);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError('');
+    setIsLoading(true);
+
+    try {
+      const response = await authApi.login(email, password);
+      const { accessToken, user } = response.data;
+      setAuth(accessToken, user);
+      router.push('/dashboard');
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Login failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-md">
+        <div className="card p-6">
+          <h1 className="text-3xl font-heading">Sign in</h1>
+          <p className="mt-2 text-sm text-muted">Access merch and clienteling tools.</p>
+          {error && (
+            <div className="mt-4 rounded-xl bg-white/80 p-3 text-sm text-red-600">
+              {error}
+            </div>
+          )}
+          <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+            <input
+              required
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="w-full rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+            />
+            <input
+              required
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="w-full rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+            />
+            <button className="btn-primary w-full" type="submit" disabled={isLoading}>
+              {isLoading ? 'Signing in...' : 'Sign in'}
+            </button>
+          </form>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/clothing-store/src/app/page.tsx
+++ b/apps/web/clothing-store/src/app/page.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+import AppShell from '@/components/AppShell';
+import ProductCard from '@/components/ProductCard';
+import { brand } from '@/lib/brand';
+import { products } from '@/lib/products';
+
+const featured = products.slice(0, 3);
+
+export default function HomePage() {
+  return (
+    <AppShell>
+      <section className="grid items-center gap-10 lg:grid-cols-[1.1fr_0.9fr]">
+        <div className="space-y-6 animate-rise">
+          <span className="brand-chip">Studio Edit</span>
+          <h1 className="text-5xl font-heading md:text-6xl">
+            Quiet luxury, everyday ease.
+          </h1>
+          <p className="text-lg text-muted">{brand.tagline}</p>
+          <div className="flex flex-wrap gap-3">
+            <Link className="btn-primary" href="/products">
+              Shop apparel
+            </Link>
+            <Link className="btn-secondary" href="/dashboard">
+              View dashboard
+            </Link>
+          </div>
+          <div className="flex flex-wrap gap-8 text-sm text-muted">
+            <div>
+              <p className="text-2xl font-semibold text-ink">320</p>
+              <p>Pieces curated</p>
+            </div>
+            <div>
+              <p className="text-2xl font-semibold text-ink">24</p>
+              <p>Limited runs</p>
+            </div>
+            <div>
+              <p className="text-2xl font-semibold text-ink">4.9</p>
+              <p>Average rating</p>
+            </div>
+          </div>
+        </div>
+        <div className="card space-y-4 p-6 animate-rise-delayed">
+          <p className="text-sm uppercase tracking-[0.3em] text-muted">Style Map</p>
+          <h2 className="text-3xl font-heading">Build your capsule</h2>
+          <p className="text-sm text-muted">
+            Curate a wardrobe in three steps with guided pairings.
+          </p>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="rounded-2xl bg-white/70 p-4">
+              <p className="text-sm text-muted">Essentials</p>
+              <p className="text-lg font-semibold">Soft structure</p>
+            </div>
+            <div className="rounded-2xl bg-white/70 p-4">
+              <p className="text-sm text-muted">Formal</p>
+              <p className="text-lg font-semibold">Refined lines</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-12 space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="section-title">Featured looks</h2>
+          <Link className="text-sm text-muted" href="/products">
+            Browse all
+          </Link>
+        </div>
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {featured.map((product) => (
+            <ProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      </section>
+    </AppShell>
+  );
+}

--- a/apps/web/clothing-store/src/app/products/[id]/page.tsx
+++ b/apps/web/clothing-store/src/app/products/[id]/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import AppShell from '@/components/AppShell';
+import { findProduct } from '@/lib/products';
+import { useCartStore } from '@/store';
+
+export default function ProductDetailPage() {
+  const params = useParams();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  const product = findProduct(id ?? '');
+  const addItem = useCartStore((state) => state.addItem);
+
+  if (!product) {
+    return (
+      <AppShell>
+        <div className="card p-6">
+          <p className="text-lg font-semibold">Product not found</p>
+          <p className="text-muted">Return to the catalog to explore more.</p>
+        </div>
+      </AppShell>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="grid gap-10 lg:grid-cols-2">
+        <div className="card p-6">
+          <div className="h-72 rounded-2xl" style={{ background: product.gradient }} />
+          <div className="mt-6 flex items-center justify-between text-sm text-muted">
+            <span>{product.rating.toFixed(1)} rating</span>
+            <span>{product.stock} pieces available</span>
+          </div>
+        </div>
+        <div className="space-y-6">
+          <p className="text-xs uppercase tracking-[0.2em] text-muted">
+            {product.category}
+          </p>
+          <h1 className="text-4xl font-heading">{product.name}</h1>
+          <p className="text-lg text-muted">{product.tagline}</p>
+          <div className="flex items-center gap-4">
+            <span className="text-2xl font-semibold">${product.price.toFixed(0)}</span>
+            <span className="rounded-full bg-white/80 px-3 py-1 text-xs text-muted">
+              Free tailoring
+            </span>
+          </div>
+          <button
+            className="btn-primary"
+            onClick={() =>
+              addItem({
+                id: product.id,
+                name: product.name,
+                price: product.price,
+                quantity: 1,
+              })
+            }
+          >
+            Add to cart
+          </button>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-2xl bg-white/80 p-4">
+              <p className="text-sm text-muted">Fabric</p>
+              <p className="text-lg font-semibold">Premium blend</p>
+            </div>
+            <div className="rounded-2xl bg-white/80 p-4">
+              <p className="text-sm text-muted">Care</p>
+              <p className="text-lg font-semibold">Easy wash</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/clothing-store/src/app/products/page.tsx
+++ b/apps/web/clothing-store/src/app/products/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import AppShell from '@/components/AppShell';
+import ProductCard from '@/components/ProductCard';
+import { categories, products } from '@/lib/products';
+
+export default function ProductsPage() {
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState('All');
+
+  const filtered = useMemo(() => {
+    return products.filter((product) => {
+      const matchesQuery = product.name.toLowerCase().includes(query.toLowerCase());
+      const matchesCategory = category === 'All' || product.category === category;
+      return matchesQuery && matchesCategory;
+    });
+  }, [query, category]);
+
+  return (
+    <AppShell>
+      <div className="space-y-8">
+        <div className="card p-6">
+          <h1 className="text-3xl font-heading">Shop the collection</h1>
+          <p className="mt-2 text-sm text-muted">
+            Filter by edit or search for your favorites.
+          </p>
+          <div className="mt-4 flex flex-col gap-4 md:flex-row md:items-center">
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search styles"
+              className="w-full rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+            />
+            <select
+              value={category}
+              onChange={(event) => setCategory(event.target.value)}
+              className="rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+            >
+              <option value="All">All categories</option>
+              {categories.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((product) => (
+            <ProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/clothing-store/src/app/register/page.tsx
+++ b/apps/web/clothing-store/src/app/register/page.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import AppShell from '@/components/AppShell';
+import { authApi } from '@/lib/api';
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [form, setForm] = useState({
+    fullName: '',
+    email: '',
+    password: '',
+    phone: '',
+    role: 'CUSTOMER',
+  });
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleChange = (key: string, value: string) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError('');
+    setSuccess('');
+
+    try {
+      await authApi.register(form);
+      setSuccess('Account created. You can sign in now.');
+      setTimeout(() => router.push('/login'), 800);
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Registration failed');
+    }
+  };
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-md">
+        <div className="card p-6">
+          <h1 className="text-3xl font-heading">Create account</h1>
+          <p className="mt-2 text-sm text-muted">Set up access for team or customer roles.</p>
+          {error && (
+            <div className="mt-4 rounded-xl bg-white/80 p-3 text-sm text-red-600">
+              {error}
+            </div>
+          )}
+          {success && (
+            <div className="mt-4 rounded-xl bg-white/80 p-3 text-sm text-green-700">
+              {success}
+            </div>
+          )}
+          <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+            <input
+              required
+              placeholder="Full name"
+              value={form.fullName}
+              onChange={(event) => handleChange('fullName', event.target.value)}
+              className="w-full rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+            />
+            <input
+              required
+              type="email"
+              placeholder="Email"
+              value={form.email}
+              onChange={(event) => handleChange('email', event.target.value)}
+              className="w-full rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+            />
+            <input
+              required
+              type="password"
+              placeholder="Password"
+              value={form.password}
+              onChange={(event) => handleChange('password', event.target.value)}
+              className="w-full rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+            />
+            <input
+              placeholder="Phone"
+              value={form.phone}
+              onChange={(event) => handleChange('phone', event.target.value)}
+              className="w-full rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+            />
+            <select
+              value={form.role}
+              onChange={(event) => handleChange('role', event.target.value)}
+              className="w-full rounded-full border border-white/70 bg-white/80 px-4 py-2 text-sm"
+            >
+              <option value="CUSTOMER">Customer</option>
+              <option value="STORE_MANAGER">Store manager</option>
+              <option value="ADMIN">Admin</option>
+            </select>
+            <button className="btn-primary w-full" type="submit">
+              Create account
+            </button>
+          </form>
+        </div>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/clothing-store/src/components/AppShell.tsx
+++ b/apps/web/clothing-store/src/components/AppShell.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useAuthStore, useCartStore } from '@/store';
+import { brand } from '@/lib/brand';
+
+const navItems = [
+  { label: 'Home', href: '/' },
+  { label: 'Products', href: '/products' },
+  { label: 'Cart', href: '/cart' },
+  { label: 'Checkout', href: '/checkout' },
+  { label: 'Dashboard', href: '/dashboard' },
+];
+
+export default function AppShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const token = useAuthStore((state) => state.token);
+  const clearAuth = useAuthStore((state) => state.clearAuth);
+  const items = useCartStore((state) => state.items);
+  const cartCount = items.reduce((sum, item) => sum + item.quantity, 0);
+
+  const isActive = (href: string) =>
+    href === '/' ? pathname === '/' : pathname.startsWith(href);
+
+  return (
+    <div className="min-h-screen">
+      <header className="sticky top-0 z-20 border-b border-white/60 bg-white/70 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-6 px-6 py-4">
+          <Link href="/" className="font-heading text-3xl tracking-wide">
+            {brand.name}
+          </Link>
+          <nav className="hidden items-center gap-5 text-sm md:flex">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`transition ${
+                  isActive(item.href) ? 'text-brand' : 'text-muted'
+                }`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <div className="flex items-center gap-3 text-sm">
+            <Link href="/cart" className="text-muted">
+              Cart ({cartCount})
+            </Link>
+            {token ? (
+              <button className="btn-secondary" onClick={clearAuth}>
+                Logout
+              </button>
+            ) : (
+              <Link className="btn-primary" href="/login">
+                Sign in
+              </Link>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-6xl px-6 py-10">{children}</main>
+
+      <footer className="mx-auto max-w-6xl px-6 pb-10 text-sm text-muted">
+        <div className="flex flex-col gap-2 border-t border-white/60 pt-6 md:flex-row md:items-center md:justify-between">
+          <span>{brand.description}</span>
+          <span>Support: atelier@clothing.demo</span>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/clothing-store/src/components/ProductCard.tsx
+++ b/apps/web/clothing-store/src/components/ProductCard.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import { useCartStore } from '@/store';
+import { Product } from '@/lib/products';
+
+export default function ProductCard({ product }: { product: Product }) {
+  const addItem = useCartStore((state) => state.addItem);
+
+  return (
+    <div className="card flex h-full flex-col gap-4 p-5">
+      <div className="h-32 rounded-xl" style={{ background: product.gradient }} />
+      <div className="flex-1 space-y-2">
+        <p className="text-xs uppercase tracking-[0.2em] text-muted">
+          {product.category}
+        </p>
+        <Link
+          href={`/products/${product.id}`}
+          className="block text-lg font-semibold"
+        >
+          {product.name}
+        </Link>
+        <p className="text-sm text-muted">{product.tagline}</p>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-lg font-semibold">${product.price.toFixed(0)}</span>
+        <button
+          className="btn-primary"
+          onClick={() =>
+            addItem({
+              id: product.id,
+              name: product.name,
+              price: product.price,
+              quantity: 1,
+            })
+          }
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/clothing-store/src/components/ProtectedGate.tsx
+++ b/apps/web/clothing-store/src/components/ProtectedGate.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/store';
+
+export default function ProtectedGate({
+  children,
+  requiredRoles = [],
+}: {
+  children: React.ReactNode;
+  requiredRoles?: string[];
+}) {
+  const router = useRouter();
+  const token = useAuthStore((state) => state.token);
+  const user = useAuthStore((state) => state.user);
+
+  useEffect(() => {
+    if (!token) {
+      router.replace('/login');
+    }
+  }, [token, router]);
+
+  if (!token) {
+    return (
+      <div className="card p-6 text-center">
+        <p className="text-muted">Redirecting to login...</p>
+      </div>
+    );
+  }
+
+  if (requiredRoles.length && !requiredRoles.some((role) => user?.roles?.includes(role))) {
+    return (
+      <div className="card p-6 text-center">
+        <p className="text-lg font-semibold">Access restricted</p>
+        <p className="text-muted">Your role does not grant access to this dashboard.</p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/clothing-store/src/lib/api.ts
+++ b/apps/web/clothing-store/src/lib/api.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+const apiClient = axios.create({
+  baseURL: API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+apiClient.interceptors.request.use((config) => {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  if (token && config.headers) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('token');
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  }
+);
+
+export const authApi = {
+  login: (email: string, password: string) =>
+    apiClient.post('/auth/login', { email, password }),
+  register: (data: Record<string, any>) =>
+    apiClient.post('/auth/register', data),
+  getCurrentUser: () => apiClient.get('/auth/me'),
+};
+
+export default apiClient;

--- a/apps/web/clothing-store/src/lib/brand.ts
+++ b/apps/web/clothing-store/src/lib/brand.ts
@@ -1,0 +1,7 @@
+export const brand = {
+  name: 'Clothing Atelier',
+  tagline: 'Layered essentials with quiet confidence.',
+  description: 'Tailored staples curated for modern wardrobes.',
+};
+
+export const dashboardRoles = ['ADMIN', 'STORE_MANAGER'];

--- a/apps/web/clothing-store/src/lib/products.ts
+++ b/apps/web/clothing-store/src/lib/products.ts
@@ -1,0 +1,100 @@
+export type Product = {
+  id: string;
+  name: string;
+  tagline: string;
+  category: string;
+  price: number;
+  rating: number;
+  stock: number;
+  gradient: string;
+};
+
+export const products: Product[] = [
+  {
+    id: 'linen-field-jacket',
+    name: 'Linen Field Jacket',
+    tagline: 'Lightweight layers for crisp mornings',
+    category: 'Outerwear',
+    price: 168,
+    rating: 4.7,
+    stock: 14,
+    gradient: 'linear-gradient(135deg, #e6dada, #274046)',
+  },
+  {
+    id: 'softline-tee',
+    name: 'Softline Tee',
+    tagline: 'Breathable cotton, refined drape',
+    category: 'Essentials',
+    price: 52,
+    rating: 4.6,
+    stock: 36,
+    gradient: 'linear-gradient(135deg, #fdfbfb, #ebedee)',
+  },
+  {
+    id: 'studio-trouser',
+    name: 'Studio Trouser',
+    tagline: 'Tailored ease with stretch',
+    category: 'Tailored',
+    price: 124,
+    rating: 4.5,
+    stock: 20,
+    gradient: 'linear-gradient(135deg, #c9d6ff, #e2e2e2)',
+  },
+  {
+    id: 'silk-wrap',
+    name: 'Silk Wrap Blouse',
+    tagline: 'Soft sheen for evening edits',
+    category: 'Formal',
+    price: 148,
+    rating: 4.8,
+    stock: 12,
+    gradient: 'linear-gradient(135deg, #fdf1d2, #f9a8d4)',
+  },
+  {
+    id: 'ribbed-knit',
+    name: 'Ribbed Knit',
+    tagline: 'Warm texture, clean lines',
+    category: 'Essentials',
+    price: 64,
+    rating: 4.4,
+    stock: 28,
+    gradient: 'linear-gradient(135deg, #d3cce3, #e9e4f0)',
+  },
+  {
+    id: 'drift-overshirt',
+    name: 'Drift Overshirt',
+    tagline: 'Structured and easy to layer',
+    category: 'Outerwear',
+    price: 110,
+    rating: 4.5,
+    stock: 18,
+    gradient: 'linear-gradient(135deg, #e0c3fc, #8ec5fc)',
+  },
+  {
+    id: 'garden-maxi',
+    name: 'Garden Maxi',
+    tagline: 'Flowing silhouette, soft pleats',
+    category: 'Formal',
+    price: 138,
+    rating: 4.7,
+    stock: 10,
+    gradient: 'linear-gradient(135deg, #fbc8d4, #9796f0)',
+  },
+  {
+    id: 'city-pleat',
+    name: 'City Pleat Skirt',
+    tagline: 'Movement-forward tailoring',
+    category: 'Tailored',
+    price: 118,
+    rating: 4.6,
+    stock: 16,
+    gradient: 'linear-gradient(135deg, #f5f7fa, #c3cfe2)',
+  },
+];
+
+export const categories = Array.from(
+  new Set(products.map((product) => product.category))
+);
+
+export const findProduct = (id: string) =>
+  products.find((product) => product.id === id);

--- a/apps/web/clothing-store/src/store/index.ts
+++ b/apps/web/clothing-store/src/store/index.ts
@@ -1,0 +1,83 @@
+import { create } from 'zustand';
+
+export interface UserProfile {
+  id: string;
+  fullName: string;
+  email: string;
+  roles: string[];
+}
+
+interface AuthStore {
+  token: string | null;
+  user: UserProfile | null;
+  setAuth: (token: string, user: UserProfile) => void;
+  clearAuth: () => void;
+}
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  token: typeof window !== 'undefined' ? localStorage.getItem('token') : null,
+  user: null,
+  setAuth: (token: string, user: UserProfile) => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('token', token);
+    }
+    set({ token, user });
+  },
+  clearAuth: () => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('token');
+    }
+    set({ token: null, user: null });
+  },
+}));
+
+export interface CartItem {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+interface CartStore {
+  items: CartItem[];
+  addItem: (item: CartItem) => void;
+  removeItem: (id: string) => void;
+  setQuantity: (id: string, quantity: number) => void;
+  clearCart: () => void;
+}
+
+export const useCartStore = create<CartStore>((set, get) => ({
+  items: [],
+  addItem: (item: CartItem) => {
+    const items = get().items;
+    const existing = items.find((entry) => entry.id === item.id);
+    if (existing) {
+      set({
+        items: items.map((entry) =>
+          entry.id === item.id
+            ? { ...entry, quantity: entry.quantity + item.quantity }
+            : entry
+        ),
+      });
+      return;
+    }
+    set({ items: [...items, item] });
+  },
+  removeItem: (id: string) => {
+    set({ items: get().items.filter((entry) => entry.id !== id) });
+  },
+  setQuantity: (id: string, quantity: number) => {
+    if (quantity <= 0) {
+      set({ items: get().items.filter((entry) => entry.id !== id) });
+      return;
+    }
+    set({
+      items: get().items.map((entry) =>
+        entry.id === id ? { ...entry, quantity } : entry
+      ),
+    });
+  },
+  clearCart: () => {
+    set({ items: [] });
+  },
+}));

--- a/apps/web/clothing-store/tailwind.config.js
+++ b/apps/web/clothing-store/tailwind.config.js
@@ -1,0 +1,28 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: 'var(--brand)',
+        accent: 'var(--accent)',
+        ink: 'var(--ink)',
+        surface: 'var(--surface)',
+        surface2: 'var(--surface-2)',
+        muted: 'var(--muted)',
+      },
+      fontFamily: {
+        heading: ['var(--font-heading)'],
+        body: ['var(--font-body)'],
+      },
+      boxShadow: {
+        glow: '0 24px 40px -26px rgba(91, 123, 122, 0.45)',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/apps/web/clothing-store/tsconfig.json
+++ b/apps/web/clothing-store/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "allowJs": true,
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "src",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
### Pull Request Description

## Overview
Build a polished apparel storefront with separated scaffold, shared components, and routed pages.

## Changes Implemented

### Features
- Added the app scaffold and Next.js tooling for the storefront.
- Added shared shell, product card, brand data, API helper, and store state.
- Implemented the landing page, product flows, auth screens, and dashboard routes.

### Refactors
- Split the work into a scaffold commit, a reusable layer commit, and a routes/styling commit.

### Fixes
- No bug fixes were required for this change set.

### Infrastructure / Config
- Added app-local config files and port-specific package scripts.

### UI / UX
- Added a branded landing experience and consistent global styling across the app.

## Technical Notes
- The branch history is intentionally granular for reviewability.
- The app is isolated to its own branch so the storefronts can be reviewed independently.

## Testing
- [x] Diff/whitespace validation on each commit
- [ ] Unit tested
- [ ] Manual tested
- [ ] API tested
- [ ] Build verified

## Impact
Impacts $(System.Collections.Hashtable.Branch) and the app under pps/web/clothing-store.

## Related Issues
Closes #103