### PR TITLE
fix(ci): stabilize monorepo workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   service-tests:
     name: Run tests per service
@@ -67,11 +70,14 @@ jobs:
           CI: true
         run: |
           if [ -f package.json ]; then
-            # allow services with no tests to succeed, but still fail on real test failures
-            if yarn test --silent -- --passWithNoTests; then
-              echo 'tests OK'
+            if node -e "const pkg = require('./package.json'); process.exit(pkg.scripts && pkg.scripts.test ? 0 : 1)"; then
+              if yarn test --silent; then
+                echo 'tests OK'
+              else
+                exit 1
+              fi
             else
-              exit 1
+              echo 'no test script'
             fi
           fi
 

--- a/.github/workflows/inventory-integration.yml
+++ b/.github/workflows/inventory-integration.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   inventory-integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/notification-service-ci.yml
+++ b/.github/workflows/notification-service-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ 'main' ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Test & Build Notification Service
@@ -24,7 +27,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          
 
       - name: Cache Yarn
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- Updated CI workflows to use the repository Yarn lockfile with explicit Yarn cache handling.
- Skipped test execution for packages that do not define a `test` script.
- Fixed the `notifyOrder` TypeScript error in the inventory service.
- Opted JavaScript actions into Node 24 to avoid the deprecation warning.

## Verification
- The latest Inventory integration workflow passed successfully.
- The Node 20 notice is now non-blocking because JavaScript actions are forced onto Node 24.