### PR TITLE
fix(ci): lowercase ghcr image owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set lowercase image owner
+        run: echo "IMAGE_OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -105,7 +108,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ env.IMAGE_OWNER }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push images
@@ -115,7 +118,7 @@ jobs:
           file: services/auth-service/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/auth-service:${{ github.sha }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/auth-service:${{ github.sha }}
 
       - name: Build product-service image
         uses: docker/build-push-action@v4
@@ -124,7 +127,7 @@ jobs:
           file: services/product-service/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/product-service:${{ github.sha }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/product-service:${{ github.sha }}
 
       - name: Build inventory-service image
         uses: docker/build-push-action@v4
@@ -133,7 +136,7 @@ jobs:
           file: services/inventory-service/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/inventory-service:${{ github.sha }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/inventory-service:${{ github.sha }}
 
       - name: Build delivery-service image
         uses: docker/build-push-action@v4
@@ -142,7 +145,7 @@ jobs:
           file: services/delivery-service/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/delivery-service:${{ github.sha }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/delivery-service:${{ github.sha }}
 
       - name: Build warehouse-service image
         uses: docker/build-push-action@v4
@@ -151,7 +154,7 @@ jobs:
           file: services/warehouse-service/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/warehouse-service:${{ github.sha }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/warehouse-service:${{ github.sha }}
 
       - name: Build notification-service image
         uses: docker/build-push-action@v4
@@ -160,4 +163,4 @@ jobs:
           file: services/notification-service/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/notification-service:${{ github.sha }}
+            ghcr.io/${{ env.IMAGE_OWNER }}/notification-service:${{ github.sha }}


### PR DESCRIPTION
## Summary
- Updated the GHCR image tags to use a lowercase owner so Docker accepts the repository name.
- Reused that same lowercase owner for GHCR login and every service image tag.

## Verification
- The workflow YAML diff was checked cleanly.
- The fix is pushed on `fix/ci-yarn-lock`, and the next main workflow run should publish the images successfully.