### PR TITLE
fix(docker): resolve workspace types in service images

### DIFF
--- a/services/auth-service/Dockerfile
+++ b/services/auth-service/Dockerfile
@@ -6,11 +6,16 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-# Copy package files
-COPY services/auth-service/package.json .
-COPY services/auth-service/tsconfig.json .
-COPY services/auth-service/prisma ./prisma
-RUN yarn install
+
+# Copy workspace manifests and shared types so Yarn resolves the local package.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/auth-service/package.json ./services/auth-service/package.json
+COPY services/auth-service/tsconfig.json ./services/auth-service/tsconfig.json
+COPY services/auth-service/prisma ./services/auth-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive
+
+WORKDIR /app/services/auth-service
 RUN npx prisma generate
 
 # Copy source
@@ -27,15 +32,18 @@ WORKDIR /app
 # Install dumb-init for proper signal handling
 RUN apk add --no-cache dumb-init
 
-# Copy package files
-COPY services/auth-service/package.json .
-COPY services/auth-service/prisma ./prisma
-RUN yarn install --production
+# Copy workspace manifests and shared types so runtime resolution matches build.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/auth-service/package.json ./services/auth-service/package.json
+COPY services/auth-service/prisma ./services/auth-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive --production
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 
 # Copy built app
-COPY --from=builder /app/dist ./dist
+WORKDIR /app/services/auth-service
+COPY --from=builder /app/services/auth-service/dist ./dist
 
 # Create non-root user
 RUN addgroup -g 1001 -S nodejs && \

--- a/services/delivery-service/Dockerfile
+++ b/services/delivery-service/Dockerfile
@@ -6,10 +6,16 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY services/delivery-service/package.json .
-COPY services/delivery-service/tsconfig.json .
-COPY services/delivery-service/prisma ./prisma
-RUN yarn install
+
+# Copy workspace manifests and shared types so Yarn resolves the local package.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/delivery-service/package.json ./services/delivery-service/package.json
+COPY services/delivery-service/tsconfig.json ./services/delivery-service/tsconfig.json
+COPY services/delivery-service/prisma ./services/delivery-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive
+
+WORKDIR /app/services/delivery-service
 
 COPY services/delivery-service/src ./src
 
@@ -21,11 +27,16 @@ WORKDIR /app
 
 RUN apk add --no-cache dumb-init
 
-COPY services/delivery-service/package.json .
-COPY services/delivery-service/prisma ./prisma
-RUN yarn install --production
 
-COPY --from=builder /app/dist ./dist
+# Copy workspace manifests and shared types so runtime resolution matches build.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/delivery-service/package.json ./services/delivery-service/package.json
+COPY services/delivery-service/prisma ./services/delivery-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive --production
+
+WORKDIR /app/services/delivery-service
+COPY --from=builder /app/services/delivery-service/dist ./dist
 
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001

--- a/services/inventory-service/Dockerfile
+++ b/services/inventory-service/Dockerfile
@@ -6,10 +6,17 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY services/inventory-service/package.json .
-COPY services/inventory-service/tsconfig.json .
-COPY services/inventory-service/prisma ./prisma
-RUN yarn install
+
+# Copy workspace manifests and shared types so Yarn resolves the local package.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/inventory-service/package.json ./services/inventory-service/package.json
+COPY services/inventory-service/tsconfig.json ./services/inventory-service/tsconfig.json
+COPY services/inventory-service/prisma ./services/inventory-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive
+
+WORKDIR /app/services/inventory-service
+
 RUN npx prisma generate
 
 COPY services/inventory-service/src ./src
@@ -22,13 +29,18 @@ WORKDIR /app
 
 RUN apk add --no-cache dumb-init
 
-COPY services/inventory-service/package.json .
-COPY services/inventory-service/prisma ./prisma
-RUN yarn install --production
+
+# Copy workspace manifests and shared types so runtime resolution matches build.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/inventory-service/package.json ./services/inventory-service/package.json
+COPY services/inventory-service/prisma ./services/inventory-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive --production
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 
-COPY --from=builder /app/dist ./dist
+WORKDIR /app/services/inventory-service
+COPY --from=builder /app/services/inventory-service/dist ./dist
 
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001

--- a/services/notification-service/Dockerfile
+++ b/services/notification-service/Dockerfile
@@ -6,10 +6,16 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY services/notification-service/package.json .
-COPY services/notification-service/tsconfig.json .
-COPY services/notification-service/prisma ./prisma
-RUN yarn install
+
+# Copy workspace manifests and shared types so Yarn resolves the local package.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/notification-service/package.json ./services/notification-service/package.json
+COPY services/notification-service/tsconfig.json ./services/notification-service/tsconfig.json
+COPY services/notification-service/prisma ./services/notification-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive
+
+WORKDIR /app/services/notification-service
 
 COPY services/notification-service/src ./src
 
@@ -21,11 +27,16 @@ WORKDIR /app
 
 RUN apk add --no-cache dumb-init
 
-COPY services/notification-service/package.json .
-COPY services/notification-service/prisma ./prisma
-RUN yarn install --production
 
-COPY --from=builder /app/dist ./dist
+# Copy workspace manifests and shared types so runtime resolution matches build.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/notification-service/package.json ./services/notification-service/package.json
+COPY services/notification-service/prisma ./services/notification-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive --production
+
+WORKDIR /app/services/notification-service
+COPY --from=builder /app/services/notification-service/dist ./dist
 
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001

--- a/services/order-service/Dockerfile
+++ b/services/order-service/Dockerfile
@@ -6,10 +6,16 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY services/order-service/package.json .
-COPY services/order-service/tsconfig.json .
-COPY services/order-service/prisma ./prisma
-RUN yarn install
+
+# Copy workspace manifests and shared types so Yarn resolves the local package.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/order-service/package.json ./services/order-service/package.json
+COPY services/order-service/tsconfig.json ./services/order-service/tsconfig.json
+COPY services/order-service/prisma ./services/order-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive
+
+WORKDIR /app/services/order-service
 RUN npx prisma generate
 
 COPY services/order-service/src ./src
@@ -22,13 +28,18 @@ WORKDIR /app
 
 RUN apk add --no-cache dumb-init
 
-COPY services/order-service/package.json .
-COPY services/order-service/prisma ./prisma
-RUN yarn install --production
+
+# Copy workspace manifests and shared types so runtime resolution matches build.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/order-service/package.json ./services/order-service/package.json
+COPY services/order-service/prisma ./services/order-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive --production
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 
-COPY --from=builder /app/dist ./dist
+WORKDIR /app/services/order-service
+COPY --from=builder /app/services/order-service/dist ./dist
 
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001

--- a/services/product-service/Dockerfile
+++ b/services/product-service/Dockerfile
@@ -6,10 +6,16 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY services/product-service/package.json .
-COPY services/product-service/tsconfig.json .
-COPY services/product-service/prisma ./prisma
-RUN yarn install
+
+# Copy workspace manifests and shared types so Yarn resolves the local package.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/product-service/package.json ./services/product-service/package.json
+COPY services/product-service/tsconfig.json ./services/product-service/tsconfig.json
+COPY services/product-service/prisma ./services/product-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive
+
+WORKDIR /app/services/product-service
 RUN npx prisma generate
 
 COPY services/product-service/src ./src
@@ -22,13 +28,18 @@ WORKDIR /app
 
 RUN apk add --no-cache dumb-init
 
-COPY services/product-service/package.json .
-COPY services/product-service/prisma ./prisma
-RUN yarn install --production
+
+# Copy workspace manifests and shared types so runtime resolution matches build.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/product-service/package.json ./services/product-service/package.json
+COPY services/product-service/prisma ./services/product-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive --production
 COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/node_modules/@prisma ./node_modules/@prisma
 
-COPY --from=builder /app/dist ./dist
+WORKDIR /app/services/product-service
+COPY --from=builder /app/services/product-service/dist ./dist
 
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001

--- a/services/warehouse-service/Dockerfile
+++ b/services/warehouse-service/Dockerfile
@@ -6,10 +6,16 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY services/warehouse-service/package.json .
-COPY services/warehouse-service/tsconfig.json .
-COPY services/warehouse-service/prisma ./prisma
-RUN yarn install
+
+# Copy workspace manifests and shared types so Yarn resolves the local package.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/warehouse-service/package.json ./services/warehouse-service/package.json
+COPY services/warehouse-service/tsconfig.json ./services/warehouse-service/tsconfig.json
+COPY services/warehouse-service/prisma ./services/warehouse-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive
+
+WORKDIR /app/services/warehouse-service
 
 COPY services/warehouse-service/src ./src
 
@@ -21,11 +27,16 @@ WORKDIR /app
 
 RUN apk add --no-cache dumb-init
 
-COPY services/warehouse-service/package.json .
-COPY services/warehouse-service/prisma ./prisma
-RUN yarn install --production
 
-COPY --from=builder /app/dist ./dist
+# Copy workspace manifests and shared types so runtime resolution matches build.
+COPY package.json yarn.lock ./
+COPY packages/types ./packages/types
+COPY services/warehouse-service/package.json ./services/warehouse-service/package.json
+COPY services/warehouse-service/prisma ./services/warehouse-service/prisma
+RUN yarn install --frozen-lockfile --non-interactive --production
+
+WORKDIR /app/services/warehouse-service
+COPY --from=builder /app/services/warehouse-service/dist ./dist
 
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001


### PR DESCRIPTION
## Summary
- Switched the service Docker builds to install from the repository workspace root so the local `@commerce/types` package resolves correctly.
- Kept the same workspace-aware layout in the runtime stage to match the builder image.

## Verification
- `git diff --check` passed on all updated Dockerfiles.
- I could not run a local Docker build here because the `docker` CLI is not available in this environment.