### PR TITLE
fix(ci): warehouse build and workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
       - name: Cache Yarn
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/yarn

--- a/services/warehouse-service/src/modules/warehouse/dtos/create-warehouse-distribution.dto.ts
+++ b/services/warehouse-service/src/modules/warehouse/dtos/create-warehouse-distribution.dto.ts
@@ -3,19 +3,19 @@ import { IsString, IsNotEmpty, IsInt, Min, IsOptional, IsDateString } from 'clas
 export class CreateWarehouseDistributionDto {
   @IsString()
   @IsNotEmpty()
-  warehouseId: string;
+  warehouseId!: string;
 
   @IsString()
   @IsNotEmpty()
-  storeId: string;
+  storeId!: string;
 
   @IsString()
   @IsNotEmpty()
-  productId: string;
+  productId!: string;
 
   @IsInt()
   @Min(1)
-  quantity: number;
+  quantity!: number;
 
   @IsDateString()
   @IsOptional()

--- a/services/warehouse-service/src/modules/warehouse/dtos/create-warehouse-transaction.dto.ts
+++ b/services/warehouse-service/src/modules/warehouse/dtos/create-warehouse-transaction.dto.ts
@@ -3,19 +3,19 @@ import { IsString, IsNotEmpty, IsInt, Min, IsOptional } from 'class-validator';
 export class CreateWarehouseTransactionDto {
   @IsString()
   @IsNotEmpty()
-  warehouseId: string;
+  warehouseId!: string;
 
   @IsString()
   @IsNotEmpty()
-  productId: string;
+  productId!: string;
 
   @IsInt()
   @Min(1)
-  quantity: number;
+  quantity!: number;
 
   @IsString()
   @IsNotEmpty()
-  type: string;
+  type!: string;
 
   @IsString()
   @IsOptional()

--- a/services/warehouse-service/src/modules/warehouse/dtos/create-warehouse.dto.ts
+++ b/services/warehouse-service/src/modules/warehouse/dtos/create-warehouse.dto.ts
@@ -3,15 +3,15 @@ import { IsString, IsNotEmpty, IsInt, Min, IsOptional } from 'class-validator';
 export class CreateWarehouseDto {
   @IsString()
   @IsNotEmpty()
-  name: string;
+  name!: string;
 
   @IsString()
   @IsNotEmpty()
-  location: string;
+  location!: string;
 
   @IsInt()
   @Min(1)
-  capacity: number;
+  capacity!: number;
 
   @IsString()
   @IsOptional()

--- a/services/warehouse-service/src/modules/warehouse/infrastructure/repositories/warehouse.repository.ts
+++ b/services/warehouse-service/src/modules/warehouse/infrastructure/repositories/warehouse.repository.ts
@@ -3,7 +3,7 @@ import { PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class WarehouseRepository {
-  constructor(private readonly prisma: PrismaClient) {}
+  constructor(private readonly prisma: any) {}
 
   async createWarehouse(data: any) {
     return this.prisma.warehouse.create({ data });

--- a/services/warehouse-service/src/modules/warehouse/interfaces/http/controllers/warehouse.controller.ts
+++ b/services/warehouse-service/src/modules/warehouse/interfaces/http/controllers/warehouse.controller.ts
@@ -1,60 +1,9 @@
-import { Controller, Post, Get, Put, Body, Param, Query } from '@nestjs/common';
-import { WarehouseService } from '../../application/warehouse.service';
-import { CreateWarehouseDto } from '../../dtos/create-warehouse.dto';
-import { UpdateWarehouseDto } from '../../dtos/update-warehouse.dto';
-import { CreateWarehouseTransactionDto } from '../../dtos/create-warehouse-transaction.dto';
-import { CreateWarehouseDistributionDto } from '../../dtos/create-warehouse-distribution.dto';
-
-@Controller('warehouse')
-export class WarehouseController {
-  constructor(private readonly warehouseService: WarehouseService) {}
-
-  @Post()
-  createWarehouse(@Body() dto: CreateWarehouseDto) {
-    return this.warehouseService.createWarehouse(dto);
-  }
-
-  @Get()
-  listWarehouses(@Query('page') page: string = '1', @Query('limit') limit: string = '10') {
-    return this.warehouseService.listWarehouses(Number(page), Number(limit));
-  }
-
-  @Get(':id')
-  getWarehouse(@Param('id') id: string) {
-    return this.warehouseService.getWarehouse(id);
-  }
-
-  @Put(':id')
-  updateWarehouse(@Param('id') id: string, @Body() dto: UpdateWarehouseDto) {
-    return this.warehouseService.updateWarehouse(id, dto);
-  }
-
-  @Post('transactions')
-  recordTransaction(@Body() dto: CreateWarehouseTransactionDto) {
-    return this.warehouseService.recordTransaction(dto);
-  }
-
-  @Post('distributions')
-  createDistribution(@Body() dto: CreateWarehouseDistributionDto) {
-    return this.warehouseService.createDistribution(dto);
-  }
-
-  @Put('distributions/:id/status')
-  updateDistributionStatus(@Param('id') id: string, @Body() body: { status: string; notes?: string }) {
-    return this.warehouseService.updateDistributionStatus(id, body.status, body.notes);
-  }
-
-  @Get('distributions')
-  listDistributions(@Query('warehouseId') warehouseId?: string) {
-    return this.warehouseService.listDistributions(warehouseId);
-  }
-}
-import { Controller, Post, Get, Put, Body, Param, Query } from '@nestjs/common';
-import { WarehouseService } from '../../application/warehouse.service';
-import { CreateWarehouseDto } from '../../dtos/create-warehouse.dto';
-import { UpdateWarehouseDto } from '../../dtos/update-warehouse.dto';
-import { CreateWarehouseTransactionDto } from '../../dtos/create-warehouse-transaction.dto';
-import { CreateWarehouseDistributionDto } from '../../dtos/create-warehouse-distribution.dto';
+import { Body, Controller, Get, Param, Post, Put, Query } from '@nestjs/common';
+import { WarehouseService } from '../../../application/warehouse.service';
+import { CreateWarehouseDto } from '../../../dtos/create-warehouse.dto';
+import { UpdateWarehouseDto } from '../../../dtos/update-warehouse.dto';
+import { CreateWarehouseTransactionDto } from '../../../dtos/create-warehouse-transaction.dto';
+import { CreateWarehouseDistributionDto } from '../../../dtos/create-warehouse-distribution.dto';
 
 @Controller('warehouse')
 export class WarehouseController {


### PR DESCRIPTION
﻿Summary:
- Fix warehouse-service TypeScript build failures caused by strict property initialization in warehouse DTOs.
- Fix warehouse-service repository compilation by loosening the Prisma client typing to match the service-local generated client.
- Repair the duplicated warehouse controller block and correct relative imports.
- Upgrade the CI service-test actions to current majors compatible with the forced Node.js 24 runtime.

Validation:
- `yarn build` passes locally for `services/warehouse-service`.
- The updated workflow changes have been committed and pushed to the branch.

Next step:
- Let CI finish on PR #128 and review any remaining failures, if they appear.
